### PR TITLE
Ntrnl 254 integrate members per team method

### DIFF
--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -5,6 +5,7 @@ import {
 } from "../config/index";
 import {
     getPerTeamData,
+    setPerTeamData,
     setOrgData,
     setTeamsData,
     setMembersData,
@@ -23,7 +24,9 @@ export const main = async (org: string): Promise<void> => {
         setMembersData(members);
         setReposData(repos);
 
-        await getPerTeamData();
+        const perTeamData = await getPerTeamData();
+
+        setPerTeamData(perTeamData);
 
         setOrgData();
 

--- a/src/service/github.ts
+++ b/src/service/github.ts
@@ -1,4 +1,4 @@
-import { GitHubTeams, GitHubMembers, GitHubRepos } from "@co-digital/api-sdk/lib/api-sdk/github/type";
+import { GitHubTeams, GitHubMembers, GitHubRepos, GitHubMembersPerTeam } from "@co-digital/api-sdk/lib/api-sdk/github/type";
 import { PER_PAGE } from "../config/index";
 import { ApiResponse } from "@co-digital/api-sdk";
 import { client } from "./api";
@@ -39,7 +39,6 @@ export const getMembersData = async (memberUrl: string, members: GitHubMembers[]
         console.error(`Error: ${error.message}`);
         return [];
     }
-
 };
 
 export const getReposData = async (reposUrl: string, repos: GitHubRepos[] = [], page = 1): Promise<GitHubRepos[]> => {
@@ -59,5 +58,23 @@ export const getReposData = async (reposUrl: string, repos: GitHubRepos[] = [], 
         console.error(`Error: ${error.message}`);
         return [];
     }
+};
 
+export const getMembersPerTeamData = async (membersPerTeamUrl: string, membersPerTeam: GitHubMembersPerTeam[] = [], page = 1): Promise<GitHubMembersPerTeam[]> => {
+    try {
+        const url = `${membersPerTeamUrl}?page=${page}&per_page=${PER_PAGE}`;
+        const resp = await client.gitHub.getMembersPerTeam(url) as ApiResponse<GitHubMembersPerTeam[]>;
+        if (resp.resource) {
+            membersPerTeam = [...membersPerTeam, ...resp.resource];
+            console.log(`${url}, page ${page}, retrieved ${resp.resource.length}`);
+
+            if (resp.resource.length === PER_PAGE) {
+                return await getMembersPerTeamData(membersPerTeamUrl, membersPerTeam, page + 1);
+            }
+        }
+        return membersPerTeam;
+    } catch (error: any) {
+        console.error(`Error: ${error.message}`);
+        return [];
+    }
 };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -58,6 +58,12 @@ export interface ReposPerTeam {
   [team_name: string]: RepoPerTeam[]
 }
 
+export interface PerTeamData {
+  [team_name: string]: {
+    members: string[]
+  }
+}
+
 export enum TechEnum {
   python = "python",
   java = "java",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -104,19 +104,7 @@ export const setReposData = (repos: GitHubRepos[]) => {
 
 // ************************************************************ //
 
-export const getPerTeamData = async (): Promise<void> => {
-    for (const team of TMP_DATA["teams"]["list"]) {
-        const memberUrl = `${team["url"]}/members`;
-        const teamUrl = team["repositories_url"];
-        const teamName = team["name"];
-
-        TMP_DATA[MEMBERS_PER_TEAM_KEY][teamName] = [];
-        TMP_DATA[REPOS_PER_TEAM_KEY][teamName] = [];
-
-        await getInfo(MEMBERS_PER_TEAM_KEY, teamName, memberUrl);
-        await getInfo(REPOS_PER_TEAM_KEY, teamName, teamUrl);
-    }
-};
+export const getPerTeamData = async (): Promise<void> => {/**/};
 
 // ************************************************************ //
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,7 +9,8 @@ import {
     MemberPerTeam,
     RepoPerTeam,
     TechFile,
-    KeyEnum
+    KeyEnum,
+    PerTeamData
 } from '../types/config';
 import {
     FILES_BY_EXTENSIONS,
@@ -24,6 +25,7 @@ import {
     REPOS_PER_TEAM_KEY
 } from "../config/index";
 import { GitHubTeams, GitHubMembers, GitHubRepos } from '@co-digital/api-sdk/lib/api-sdk/github/type';
+import { getMembersPerTeamData } from '../service/github';
 
 // ************************************************************ //
 
@@ -104,7 +106,28 @@ export const setReposData = (repos: GitHubRepos[]) => {
 
 // ************************************************************ //
 
-export const getPerTeamData = async (): Promise<void> => {/**/};
+export const getPerTeamData = async (): Promise<PerTeamData> => {
+    const perTeamData: PerTeamData = {};
+    for (const team of ORG_DATA.teams.list) {
+        const teamUrl = ORG_DATA.teams.details[team].url;
+        const membersPerTeamUrl = `${teamUrl}/members`;
+
+        const membersPerTeamData = await getMembersPerTeamData(membersPerTeamUrl);
+        const members = membersPerTeamData.map(members => members.login);
+
+        perTeamData[team] = { members: members };
+    }
+    return perTeamData;
+};
+
+// ************************************************************ //
+
+export const setPerTeamData = (perTeamData: PerTeamData) => {
+    for (const team of ORG_DATA.teams.list) {
+        const orgDataTeam = ORG_DATA.teams.details[team] as TeamDetails;
+        orgDataTeam.members = perTeamData[team].members;
+    }
+};
 
 // ************************************************************ //
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -61,17 +61,6 @@ export const getInfo = async (what: string, dataKey: string, dataUrl: string, pa
 
 // ************************************************************ //
 
-export const getOrgData = async (org: string, dataKey = "list"): Promise<void> => {
-    // loop through each of teams, members and repos and use getInfo to extract the data
-    for (const what of ['repos']) {
-        console.log(`GET ${what} data:`);
-        const url = `https://api.github.com/orgs/${org}/${what}`;
-        await getInfo(what, dataKey, url);
-    }
-};
-
-// ************************************************************ //
-
 export const setTeamsData = (teams: GitHubTeams[]) => {
     teams.forEach((team) => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/test/mock/repos_info.ts
+++ b/test/mock/repos_info.ts
@@ -191,6 +191,10 @@ export const MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE = {
 
 export const MOCK_GET_MEMBERS_PER_TEAM_DATA: GitHubMembersPerTeam[] = MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE.resource;
 
+/* .getPerTeamData() MOCKS */
+
+export const GET_PER_TEAM_DATA_MOCK = { [MOCK_REPOS_TEAMS_NAME]: { members: [MOCK_REPOS_MEMBERS_NAME] } };
+
 // ************************************************************ //
 
 /* ORG DATA MOCKS */

--- a/test/mock/repos_info.ts
+++ b/test/mock/repos_info.ts
@@ -1,4 +1,4 @@
-import { GitHubTeams, GitHubMembers, GitHubRepos } from "@co-digital/api-sdk/lib/api-sdk/github/type";
+import { GitHubTeams, GitHubMembers, GitHubRepos, GitHubMembersPerTeam } from "@co-digital/api-sdk/lib/api-sdk/github/type";
 import { MEMBERS_PER_TEAM_KEY, REPOS_PER_TEAM_KEY } from "../../src/config";
 import { WhatEnum } from "../../src/types/config";
 
@@ -112,6 +112,12 @@ export const MOCK_JSON_FETCH_RESPONSE = [
     }
 ];
 
+// ************************************************************ //
+
+/* GITHUB API-SDK RESPONSE MOCKS */
+
+/* .getTeams() RESPONSE MOCKS */
+
 export const MOCK_REPOS_TEAMS_NAME = "cool-team-name";
 export const MOCK_REPOS_TEAMS_DESCRIPTION = "Teams Description";
 
@@ -131,6 +137,66 @@ export const MOCK_GET_TEAMS_API_SDK_RESPONSE = {
 
 export const MOCK_REPOS_TEAMS_DATA: GitHubTeams[] = MOCK_GET_TEAMS_API_SDK_RESPONSE.resource;
 
+/* .getMembers() RESPONSE MOCKS */
+
+export const MOCK_REPOS_MEMBERS_NAME = "cool-member";
+
+export const MOCK_GET_MEMBERS_API_SDK_RESPONSE = {
+    httpStatusCode: 200,
+    resource: [
+        {
+            "login": MOCK_REPOS_MEMBERS_NAME,
+            "url": `https://api.github.com/users/${MOCK_REPOS_MEMBERS_NAME}`,
+            "html_url": `https://github.com/${MOCK_REPOS_MEMBERS_NAME}`,
+            "repos_url": `https://api.github.com/users/${MOCK_REPOS_MEMBERS_NAME}/repos`
+        }
+    ],
+};
+
+export const MOCK_MEMBERS_TEAMS_DATA: GitHubMembers[] = MOCK_GET_MEMBERS_API_SDK_RESPONSE.resource;
+
+/* .getRepos() RESPONSE MOCKS */
+
+export const MOCK_REPO_NAME = "cool-repo-name";
+export const MOCK_REPO_DESCRIPTION = "Repos Description";
+
+export const MOCK_GET_REPOS_API_SDK_RESPONSE = {
+    httpStatusCode: 200,
+    resource: [
+        {
+            "name": `${MOCK_REPO_NAME}`,
+            "description": `${MOCK_REPO_DESCRIPTION}`,
+            "full_name": `${MOCK_ORGANIZATION}/${MOCK_REPO_NAME}`,
+            "visibility": 'public',
+            "url": `https://api.github.com/repos/${MOCK_ORGANIZATION}/${MOCK_REPO_NAME}`,
+            "html_url": `https://github.com/${MOCK_ORGANIZATION}/${MOCK_REPO_NAME}`,
+            "created_at": '2023-07-10T08:41:07Z',
+            "archived": false,
+        },
+    ],
+};
+
+export const MOCK_REPOS_REPO_DATA: GitHubRepos[] = MOCK_GET_REPOS_API_SDK_RESPONSE.resource;
+
+/* .getMembersPerTeam() RESPONSE MOCKS */
+
+export const MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE = {
+    httpStatusCode: 200,
+    resource: [
+        {
+            "login": MOCK_REPOS_MEMBERS_NAME,
+        },
+    ],
+};
+
+export const MOCK_GET_MEMBERS_PER_TEAM_DATA: GitHubMembersPerTeam[] = MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE.resource;
+
+// ************************************************************ //
+
+/* ORG DATA MOCKS */
+
+/* ORG DATA TEAMS */
+
 export const MOCK_ORG_TEAMS = {
     "teams": {
         "details": {
@@ -149,21 +215,7 @@ export const MOCK_ORG_TEAMS = {
     }
 };
 
-export const MOCK_REPOS_MEMBERS_NAME = "cool-member";
-
-export const MOCK_GET_MEMBERS_API_SDK_RESPONSE = {
-    httpStatusCode: 200,
-    resource: [
-        {
-            "login": MOCK_REPOS_MEMBERS_NAME,
-            "url": `https://api.github.com/users/${MOCK_REPOS_MEMBERS_NAME}`,
-            "html_url": `https://github.com/${MOCK_REPOS_MEMBERS_NAME}`,
-            "repos_url": `https://api.github.com/users/${MOCK_REPOS_MEMBERS_NAME}/repos`
-        }
-    ],
-};
-
-export const MOCK_MEMBERS_TEAMS_DATA: GitHubMembers[] = MOCK_GET_MEMBERS_API_SDK_RESPONSE.resource;
+/* ORG DATA MEMBERS */
 
 export const MOCK_ORG_MEMBERS = {
     "members": {
@@ -180,27 +232,8 @@ export const MOCK_ORG_MEMBERS = {
     }
 };
 
-export const MOCK_REPO_NAME = "cool-repo-name";
-export const MOCK_REPO_DESCRIPTION = "Repos Description";
+/* ORG DATA REPOS */
 
-export const MOCK_GET_REPOS_API_SDK_RESPONSE = {
-    httpStatusCode: 200,
-    resource: [
-      {
-        "name": `${MOCK_REPO_NAME}`,
-        "description": `${MOCK_REPO_DESCRIPTION}`,
-        "full_name": `${MOCK_ORGANIZATION}/${MOCK_REPO_NAME}`,
-        "visibility": 'public',
-        "url": `https://api.github.com/repos/${MOCK_ORGANIZATION}/${MOCK_REPO_NAME}`,
-        "html_url": `https://github.com/${MOCK_ORGANIZATION}/${MOCK_REPO_NAME}`,
-        "created_at": '2023-07-10T08:41:07Z',
-        "archived": false,
-      },
-    ],
-}
-
-export const MOCK_REPOS_REPO_DATA: GitHubRepos[] = MOCK_GET_REPOS_API_SDK_RESPONSE.resource;
-  
 export const MOCK_ORG_REPOS = {
     "repos": {
         "details": {
@@ -219,7 +252,9 @@ export const MOCK_ORG_REPOS = {
         "list": [MOCK_REPO_NAME]
     }
 };
-    
+
+// ************************************************************ //
+
 export const MOCK_REPOS_MEMBERS = {
     "0": {
         "login": MOCK_REPOS_MEMBERS_NAME,

--- a/test/src/scripts/main.spec.ts
+++ b/test/src/scripts/main.spec.ts
@@ -6,21 +6,22 @@ import { describe, expect, test, jest, afterEach, beforeEach } from '@jest/globa
 
 import { main } from "../../../src/scripts/main";
 import { saveToFile } from "../../../src/utils/fs";
-import { getPerTeamData, setOrgData, setTeamsData, setMembersData, setReposData } from "../../../src/utils/index";
+import { getPerTeamData, setOrgData, setTeamsData, setMembersData, setReposData, setPerTeamData } from "../../../src/utils/index";
 
 import { getTeamsData, getMembersData, getReposData } from '../../../src/service/github';
 
-import { MOCK_ORGANIZATION, MOCK_REPOS_TEAMS_DATA, MOCK_MEMBERS_TEAMS_DATA, MOCK_REPOS_REPO_DATA} from '../../mock/repos_info';
+import { MOCK_ORGANIZATION, MOCK_REPOS_TEAMS_DATA, MOCK_MEMBERS_TEAMS_DATA, MOCK_REPOS_REPO_DATA, GET_PER_TEAM_DATA_MOCK } from '../../mock/repos_info';
 import { REPOS_FILE_PATH } from '../../../src/config';
 
 const spyConsoleError = jest.spyOn(console, 'error');
 
 const mockGetTeamsData = (getTeamsData as jest.Mock<any>).mockResolvedValue(MOCK_REPOS_TEAMS_DATA);
 const mockSetTeamsData = setTeamsData as jest.Mock;
-const mockGetPerTeamData = getPerTeamData as jest.Mock;
-const mockSetMembersData = setMembersData as jest.Mock
+const mockGetPerTeamData = (getPerTeamData as jest.Mock<any>).mockResolvedValue(GET_PER_TEAM_DATA_MOCK);
+const mockSetPerTeamData = setPerTeamData as jest.Mock;
+const mockSetMembersData = setMembersData as jest.Mock;
 const mockGetMembersData = (getMembersData as jest.Mock<any>).mockResolvedValue(MOCK_MEMBERS_TEAMS_DATA);
-const mockSetReposData = setReposData as jest.Mock
+const mockSetReposData = setReposData as jest.Mock;
 const mockGetReposData = (getReposData as jest.Mock<any>).mockResolvedValue(MOCK_REPOS_REPO_DATA);
 const mockSaveToFile = saveToFile as jest.Mock;
 const mockSetOrgData = setOrgData as jest.Mock;
@@ -35,14 +36,14 @@ describe("Main tests suites", () => {
         jest.resetAllMocks();
     });
 
-    test("should call getOrgData, getTeamsData, setTeamsData, getPerTeamData and saveToFile functions", async () => {
+    test("should call github data getters/setters and saveToFile functions", async () => {
 
         await main(MOCK_ORGANIZATION);
 
-        
         expect(mockGetTeamsData).toHaveBeenCalledTimes(1);
         expect(mockGetMembersData).toBeCalledTimes(1);
         expect(mockGetReposData).toBeCalledTimes(1);
+
         expect(mockSetTeamsData).toHaveBeenCalledTimes(1);
         expect(mockSetTeamsData).toHaveBeenCalledWith(MOCK_REPOS_TEAMS_DATA);
         expect(mockSetMembersData).toBeCalledTimes(1);
@@ -52,9 +53,12 @@ describe("Main tests suites", () => {
 
         expect(mockGetPerTeamData).toHaveBeenCalledTimes(1);
 
-        expect(mockSaveToFile).toHaveBeenCalledTimes(1);
+        expect(mockSetPerTeamData).toHaveBeenCalledTimes(1);
+        expect(mockSetPerTeamData).toHaveBeenCalledWith(GET_PER_TEAM_DATA_MOCK);
+
         expect(mockSetOrgData).toHaveBeenCalledTimes(1);
 
+        expect(mockSaveToFile).toHaveBeenCalledTimes(1);
         expect(mockSaveToFile).toHaveBeenCalledWith(REPOS_FILE_PATH, expect.anything());
 
         expect(spyConsoleError).toHaveBeenCalledTimes(0);

--- a/test/src/scripts/main.spec.ts
+++ b/test/src/scripts/main.spec.ts
@@ -6,7 +6,7 @@ import { describe, expect, test, jest, afterEach, beforeEach } from '@jest/globa
 
 import { main } from "../../../src/scripts/main";
 import { saveToFile } from "../../../src/utils/fs";
-import { getOrgData, getPerTeamData, setOrgData, setTeamsData, setMembersData, setReposData } from "../../../src/utils/index";
+import { getPerTeamData, setOrgData, setTeamsData, setMembersData, setReposData } from "../../../src/utils/index";
 
 import { getTeamsData, getMembersData, getReposData } from '../../../src/service/github';
 
@@ -15,7 +15,6 @@ import { REPOS_FILE_PATH } from '../../../src/config';
 
 const spyConsoleError = jest.spyOn(console, 'error');
 
-const mockGetOrgData = getOrgData as jest.Mock;
 const mockGetTeamsData = (getTeamsData as jest.Mock<any>).mockResolvedValue(MOCK_REPOS_TEAMS_DATA);
 const mockSetTeamsData = setTeamsData as jest.Mock;
 const mockGetPerTeamData = getPerTeamData as jest.Mock;

--- a/test/src/service/github.spec.ts
+++ b/test/src/service/github.spec.ts
@@ -1,6 +1,6 @@
 import { jest, describe, beforeEach, test, expect } from '@jest/globals';
-import { getTeamsData, getMembersData, getReposData} from "../../../src/service/github";
-import { MOCK_GET_TEAMS_API_SDK_RESPONSE, MOCK_GET_MEMBERS_API_SDK_RESPONSE, MOCK_GET_REPOS_API_SDK_RESPONSE } from "../../mock/repos_info";
+import { getTeamsData, getMembersData, getReposData, getMembersPerTeamData} from "../../../src/service/github";
+import { MOCK_GET_TEAMS_API_SDK_RESPONSE, MOCK_GET_MEMBERS_API_SDK_RESPONSE, MOCK_GET_REPOS_API_SDK_RESPONSE, MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE } from "../../mock/repos_info";
 import { client } from "../../../src/service/api";
 
 jest.mock("@co-digital/api-sdk", () => ({
@@ -8,7 +8,8 @@ jest.mock("@co-digital/api-sdk", () => ({
         gitHub: {
             getMembers: jest.fn(),
             getTeams: jest.fn(),
-            getRepos: jest.fn()
+            getRepos: jest.fn(),
+            getMembersPerTeam: jest.fn()
         },
     })),
 }));
@@ -134,6 +135,43 @@ describe("github service test suite", () => {
     
             expect(spyConsoleError).toHaveBeenCalledTimes(1);
             expect(repos).toEqual([]);
+        });
+    })
+
+    describe("getMembersPerTeam tests", () => {
+        test('should return value should be empty if no data fetched', async () => {
+            (client.gitHub.getMembersPerTeam as jest.Mock<any>).mockResolvedValue({});
+    
+            const membersPerTeam = await getMembersPerTeamData('');
+    
+            expect(spyConsoleLog).toHaveBeenCalledTimes(0);
+            expect(membersPerTeam).toEqual([]);
+        });
+
+        test('should return resource from getMembersPerTeam API SDK response if data fetched', async () => {
+            (client.gitHub.getMembersPerTeam as jest.Mock<any>).mockResolvedValue(MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE);
+    
+            const membersPerTeam = await getMembersPerTeamData('');
+    
+            expect(spyConsoleLog).toHaveBeenCalledTimes(1);
+            expect(membersPerTeam).toEqual(MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE.resource);
+        });
+    
+        test('should only call getMembersPerTeam API SDK response once if length of data fetched is not 100', async () => {
+            (client.gitHub.getMembersPerTeam as jest.Mock<any>).mockResolvedValue(MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE);
+    
+            await getMembersPerTeamData('');
+    
+            expect(client.gitHub.getMembersPerTeam).toHaveBeenCalledTimes(1);
+        });
+    
+        test('should catch a rejected promise call', async () => {
+            (client.gitHub.getMembersPerTeam as jest.Mock<any>).mockRejectedValue([]);
+    
+            const membersPerTeam = await getMembersPerTeamData('');
+    
+            expect(spyConsoleError).toHaveBeenCalledTimes(1);
+            expect(membersPerTeam).toEqual([]);
         });
         
 

--- a/test/src/service/github.spec.ts
+++ b/test/src/service/github.spec.ts
@@ -1,18 +1,23 @@
-import { jest, describe, beforeEach, test, expect } from '@jest/globals';
-import { getTeamsData, getMembersData, getReposData, getMembersPerTeamData} from "../../../src/service/github";
-import { MOCK_GET_TEAMS_API_SDK_RESPONSE, MOCK_GET_MEMBERS_API_SDK_RESPONSE, MOCK_GET_REPOS_API_SDK_RESPONSE, MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE } from "../../mock/repos_info";
-import { client } from "../../../src/service/api";
-
 jest.mock("@co-digital/api-sdk", () => ({
     createOAuthApiClient: jest.fn(() => ({
         gitHub: {
-            getMembers: jest.fn(),
             getTeams: jest.fn(),
+            getMembers: jest.fn(),
             getRepos: jest.fn(),
             getMembersPerTeam: jest.fn()
         },
     })),
 }));
+
+import { jest, describe, beforeEach, test, expect } from '@jest/globals';
+import { getTeamsData, getMembersData, getReposData, getMembersPerTeamData } from "../../../src/service/github";
+import { MOCK_GET_TEAMS_API_SDK_RESPONSE, MOCK_GET_MEMBERS_API_SDK_RESPONSE, MOCK_GET_REPOS_API_SDK_RESPONSE, MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE } from "../../mock/repos_info";
+import { client } from "../../../src/service/api";
+
+const mockGetTeams = client.gitHub.getTeams as jest.Mock<any>;
+const mockGetMembers = client.gitHub.getMembers as jest.Mock<any>;
+const mockGetRepos = client.gitHub.getRepos as jest.Mock<any>;
+const mockGetMembersPerTeam = client.gitHub.getMembersPerTeam as jest.Mock<any>;
 
 const spyConsoleError = jest.spyOn(console, 'error');
 const spyConsoleLog = jest.spyOn(console, 'log');
@@ -20,43 +25,46 @@ const spyConsoleLog = jest.spyOn(console, 'log');
 describe("github service test suite", () => {
 
     beforeEach(() => {
-        jest.resetAllMocks();
         spyConsoleLog.mockImplementation(() => {/**/});
         spyConsoleError.mockImplementation(() => {/**/});
     });
 
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
     describe("getTeamsData tests", () => {
         test('should return value should be empty if no data fetched', async () => {
-            (client.gitHub.getTeams as jest.Mock<any>).mockResolvedValue({});
-    
+            mockGetTeams.mockResolvedValue({});
+
             const teams = await getTeamsData('');
-    
+
             expect(spyConsoleLog).toHaveBeenCalledTimes(0);
             expect(teams).toEqual([]);
         });
-    
+
         test('should return resource from getTeams API SDK response if data fetched', async () => {
-            (client.gitHub.getTeams as jest.Mock<any>).mockResolvedValue(MOCK_GET_TEAMS_API_SDK_RESPONSE);
-    
+            mockGetTeams.mockResolvedValue(MOCK_GET_TEAMS_API_SDK_RESPONSE);
+
             const teams = await getTeamsData('');
-    
+
             expect(spyConsoleLog).toHaveBeenCalledTimes(1);
             expect(teams).toEqual(MOCK_GET_TEAMS_API_SDK_RESPONSE.resource);
         });
-    
+
         test('should only call getTeams API SDK response once if length of data fetched is not 100', async () => {
-            (client.gitHub.getTeams as jest.Mock<any>).mockResolvedValue(MOCK_GET_TEAMS_API_SDK_RESPONSE);
-    
+            mockGetTeams.mockResolvedValue(MOCK_GET_TEAMS_API_SDK_RESPONSE);
+
             await getTeamsData('');
-    
+
             expect(client.gitHub.getTeams).toHaveBeenCalledTimes(1);
         });
-    
+
         test('should catch a rejected promise call', async () => {
-            (client.gitHub.getTeams as jest.Mock<any>).mockRejectedValue([]);
-    
+            mockGetTeams.mockRejectedValue([]);
+
             const teams = await getTeamsData('');
-    
+
             expect(spyConsoleError).toHaveBeenCalledTimes(1);
             expect(teams).toEqual([]);
         });
@@ -65,116 +73,114 @@ describe("github service test suite", () => {
 
     describe("getMembersData tests", () => {
         test('should return value should be empty if no data fetched', async () => {
-            (client.gitHub.getMembers as jest.Mock<any>).mockResolvedValue({});
-    
+            mockGetMembers.mockResolvedValue({});
+
             const members = await getMembersData('');
-    
+
             expect(spyConsoleLog).toHaveBeenCalledTimes(0);
             expect(members).toEqual([]);
         });
 
         test('should return resource from getMembers API SDK response if data fetched', async () => {
-            (client.gitHub.getMembers as jest.Mock<any>).mockResolvedValue(MOCK_GET_MEMBERS_API_SDK_RESPONSE);
-    
+            mockGetMembers.mockResolvedValue(MOCK_GET_MEMBERS_API_SDK_RESPONSE);
+
             const members = await getMembersData('');
-    
+
             expect(spyConsoleLog).toHaveBeenCalledTimes(1);
             expect(members).toEqual(MOCK_GET_MEMBERS_API_SDK_RESPONSE.resource);
         });
-    
+
         test('should only call getMembers API SDK response once if length of data fetched is not 100', async () => {
-            (client.gitHub.getMembers as jest.Mock<any>).mockResolvedValue(MOCK_GET_MEMBERS_API_SDK_RESPONSE);
-    
+            mockGetMembers.mockResolvedValue(MOCK_GET_MEMBERS_API_SDK_RESPONSE);
+
             await getMembersData('');
-    
+
             expect(client.gitHub.getMembers).toHaveBeenCalledTimes(1);
         });
-    
+
         test('should catch a rejected promise call', async () => {
-            (client.gitHub.getMembers as jest.Mock<any>).mockRejectedValue([]);
-    
+            mockGetMembers.mockRejectedValue([]);
+
             const members = await getMembersData('');
-    
+
             expect(spyConsoleError).toHaveBeenCalledTimes(1);
             expect(members).toEqual([]);
         });
-        
 
     });
     describe("getReposData tests", () => {
         test('should return value should be empty if no data fetched', async () => {
-            (client.gitHub.getRepos as jest.Mock<any>).mockResolvedValue({});
-    
+            mockGetRepos.mockResolvedValue({});
+
             const repos = await getReposData('');
-    
+
             expect(spyConsoleLog).toHaveBeenCalledTimes(0);
             expect(repos).toEqual([]);
         });
 
         test('should return resource from getRepos API SDK response if data fetched', async () => {
-            (client.gitHub.getRepos as jest.Mock<any>).mockResolvedValue(MOCK_GET_REPOS_API_SDK_RESPONSE);
-    
+            mockGetRepos.mockResolvedValue(MOCK_GET_REPOS_API_SDK_RESPONSE);
+
             const repos = await getReposData('');
-    
+
             expect(spyConsoleLog).toHaveBeenCalledTimes(1);
             expect(repos).toEqual(MOCK_GET_REPOS_API_SDK_RESPONSE.resource);
         });
-    
+
         test('should only call getRepos API SDK response once if length of data fetched is not 100', async () => {
-            (client.gitHub.getRepos as jest.Mock<any>).mockResolvedValue(MOCK_GET_REPOS_API_SDK_RESPONSE);
-    
+            mockGetRepos.mockResolvedValue(MOCK_GET_REPOS_API_SDK_RESPONSE);
+
             await getReposData('');
-    
+
             expect(client.gitHub.getRepos).toHaveBeenCalledTimes(1);
         });
-    
+
         test('should catch a rejected promise call', async () => {
-            (client.gitHub.getRepos as jest.Mock<any>).mockRejectedValue([]);
-    
+            mockGetRepos.mockRejectedValue([]);
+
             const repos = await getReposData('');
-    
+
             expect(spyConsoleError).toHaveBeenCalledTimes(1);
             expect(repos).toEqual([]);
         });
-    })
+    });
 
     describe("getMembersPerTeam tests", () => {
         test('should return value should be empty if no data fetched', async () => {
-            (client.gitHub.getMembersPerTeam as jest.Mock<any>).mockResolvedValue({});
-    
+            mockGetMembersPerTeam.mockResolvedValue({});
+
             const membersPerTeam = await getMembersPerTeamData('');
-    
+
             expect(spyConsoleLog).toHaveBeenCalledTimes(0);
             expect(membersPerTeam).toEqual([]);
         });
 
         test('should return resource from getMembersPerTeam API SDK response if data fetched', async () => {
-            (client.gitHub.getMembersPerTeam as jest.Mock<any>).mockResolvedValue(MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE);
-    
+            mockGetMembersPerTeam.mockResolvedValue(MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE);
+
             const membersPerTeam = await getMembersPerTeamData('');
-    
+
             expect(spyConsoleLog).toHaveBeenCalledTimes(1);
             expect(membersPerTeam).toEqual(MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE.resource);
         });
-    
+
         test('should only call getMembersPerTeam API SDK response once if length of data fetched is not 100', async () => {
-            (client.gitHub.getMembersPerTeam as jest.Mock<any>).mockResolvedValue(MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE);
-    
+            mockGetMembersPerTeam.mockResolvedValue(MOCK_GET_MEMBERS_PER_TEAM_API_SDK_RESPONSE);
+
             await getMembersPerTeamData('');
-    
+
             expect(client.gitHub.getMembersPerTeam).toHaveBeenCalledTimes(1);
         });
-    
+
         test('should catch a rejected promise call', async () => {
-            (client.gitHub.getMembersPerTeam as jest.Mock<any>).mockRejectedValue([]);
-    
+            mockGetMembersPerTeam.mockRejectedValue([]);
+
             const membersPerTeam = await getMembersPerTeamData('');
-    
+
             expect(spyConsoleError).toHaveBeenCalledTimes(1);
             expect(membersPerTeam).toEqual([]);
         });
         
-
     });
 
 });

--- a/test/src/utils/index.spec.ts
+++ b/test/src/utils/index.spec.ts
@@ -1,3 +1,5 @@
+jest.mock('../../../src/service/github');
+
 import { describe, expect, test, jest, afterEach, beforeEach } from '@jest/globals';
 
 import {
@@ -9,7 +11,9 @@ import {
     setOrgData,
     setTeamsData,
     setMembersData,
-    setReposData
+    setReposData,
+    getPerTeamData,
+    setPerTeamData
 } from "../../../src/utils/index";
 
 import {
@@ -46,9 +50,16 @@ import {
     MOCK_ORG_TEAMS,
     MOCK_ORG_MEMBERS,
     MOCK_ORG_REPOS,
-    MOCK_REPOS_REPO_DATA
+    MOCK_REPOS_REPO_DATA,
+    MOCK_GET_MEMBERS_PER_TEAM_DATA,
+    GET_PER_TEAM_DATA_MOCK,
+    MOCK_REPOS_TEAMS_NAME
 } from '../../mock/repos_info';
-import { MemberDetails, RepoDetails } from '../../../src/types/config';
+
+import { MemberDetails, RepoDetails, TeamDetails } from '../../../src/types/config';
+import { getMembersPerTeamData } from '../../../src/service/github';
+
+const mockGetMembersPerTeam = getMembersPerTeamData as jest.Mock<any>;
 
 const spyConsoleLog = jest.spyOn(console, 'log');
 const spyConsoleError = jest.spyOn(console, 'error');
@@ -263,7 +274,40 @@ describe("UTILS Index tests suites", () => {
 
     // ************************************************************ //
 
-    describe("getPerTeamData(...)", () => {});
+    describe("getPerTeamData(...)", () => {
+
+        beforeEach(() => {
+            ORG_DATA["teams"]["list"] = MOCK_ORG_TEAMS["teams"]['list'];
+            ORG_DATA["teams"]["details"] = MOCK_ORG_TEAMS["teams"]["details"];
+        });
+
+        test('should return all members per teams ', async () => {
+            mockGetMembersPerTeam.mockResolvedValue(MOCK_GET_MEMBERS_PER_TEAM_DATA);
+
+            const perTeamData = await getPerTeamData();
+
+            expect(perTeamData).toEqual(GET_PER_TEAM_DATA_MOCK);
+
+        });
+    });
+
+    // ************************************************************ //
+
+    describe("getPerTeamData(...)", () => {
+
+        beforeEach(() => {
+            ORG_DATA["teams"]["list"] = MOCK_ORG_TEAMS["teams"]['list'];
+            ORG_DATA["teams"]["details"] = MOCK_ORG_TEAMS["teams"]["details"];
+        });
+
+        test('should assign members from perTeamData to ORG_DATA teams', async () => {
+            setPerTeamData(GET_PER_TEAM_DATA_MOCK);
+
+            const orgDataTeam = ORG_DATA.teams.details[MOCK_REPOS_TEAMS_NAME] as TeamDetails;
+
+            expect(orgDataTeam.members).toEqual(GET_PER_TEAM_DATA_MOCK[MOCK_REPOS_TEAMS_NAME].members);
+        });
+    });
 
     // ************************************************************ //
 

--- a/test/src/utils/index.spec.ts
+++ b/test/src/utils/index.spec.ts
@@ -4,7 +4,6 @@ import {
     getTechFile,
     updateStateFile,
     setTimeOut,
-    getPerTeamData,
     mapData,
     getInfo,
     setOrgData,
@@ -36,7 +35,6 @@ import {
     MOCK_REPO_URL,
     MOCK_REPOS_DATA,
     MOCK_REPOS_TEAMS_DATA,
-    MOCK_REPOS_TEAMS_NAME,
     MOCK_MEMBERS_TEAMS_DATA,
     MOCK_REPOS_REPOSITORIES,
     MOCK_REPOS_MEMBERS,
@@ -265,26 +263,7 @@ describe("UTILS Index tests suites", () => {
 
     // ************************************************************ //
 
-    describe("getPerTeamData(...)", () => {
-
-        test(`should correctly populate TMP_DATA with members and repos per team`, async () => {
-            TMP_DATA["teams"]["list"] = MOCK_REPOS_TEAMS_DATA;
-            TMP_DATA[MEMBERS_PER_TEAM_KEY] = {};
-            TMP_DATA[REPOS_PER_TEAM_KEY] = {};
-
-            spyFetchCall
-                .mockImplementationOnce(() => Promise.resolve({ json: () => Promise.resolve([MOCK_REPOS_MEMBERS[0]]) } as any))
-                .mockImplementationOnce(() => Promise.resolve({ json: () => Promise.resolve([MOCK_REPOS_REPOSITORIES[0]]) } as any));
-
-            await getPerTeamData();
-
-            expect(TMP_DATA["repos"]["list"]).toEqual([]);
-            expect(TMP_DATA["members"]["list"]).toEqual([]);
-            expect(TMP_DATA[MEMBERS_PER_TEAM_KEY][MOCK_REPOS_TEAMS_NAME][0].login).toEqual(MOCK_REPOS_MEMBERS_NAME);
-            expect(TMP_DATA[REPOS_PER_TEAM_KEY][MOCK_REPOS_TEAMS_NAME][0].name).toEqual(MOCK_REPOS_REPO_NAME);
-        });
-
-    });
+    describe("getPerTeamData(...)", () => {});
 
     // ************************************************************ //
 

--- a/test/src/utils/index.spec.ts
+++ b/test/src/utils/index.spec.ts
@@ -7,7 +7,6 @@ import {
     getPerTeamData,
     mapData,
     getInfo,
-    getOrgData,
     setOrgData,
     setTeamsData,
     setMembersData,
@@ -36,7 +35,6 @@ import {
     MOCK_HEADERS,
     MOCK_REPO_URL,
     MOCK_REPOS_DATA,
-    MOCK_ORGANIZATION,
     MOCK_REPOS_TEAMS_DATA,
     MOCK_REPOS_TEAMS_NAME,
     MOCK_MEMBERS_TEAMS_DATA,
@@ -217,24 +215,6 @@ describe("UTILS Index tests suites", () => {
             expect(spyConsoleLog).toHaveBeenCalledTimes(0);
             expect(spyConsoleError).toHaveBeenCalledTimes(1);
         });
-    });
-
-    // ************************************************************ //
-
-    describe("getOrgData(...)", () => {
-
-        test(`should fetch repos data`, async () => {
-
-            await getOrgData(MOCK_ORGANIZATION);
-
-            expect(spyConsoleLog).toHaveBeenCalledTimes(2);
-
-            expect(spyConsoleLog).toHaveBeenCalledWith(`GET repos data:`);
-            expect(spyConsoleLog).toHaveBeenCalledWith(`https://api.github.com/orgs/${MOCK_ORGANIZATION}/repos?page=1&per_page=100, page 1, retrieved 0`);
-
-
-        });
-
     });
 
     // ************************************************************ //


### PR DESCRIPTION
### JIRA link

[NTRNL-254](https://technologyprogramme.atlassian.net/jira/software/projects/NTRNL/boards/312?selectedIssue=NTRNL-254)

### Change description

This change integrates the `getMembersPerTeam()` method from the @co-digital/api-sdk library. Members per team can be seen on `repos_info.json` after running `make start`.

### Work checklist

- [x] Tests added where applicable
- [x] No vulnerability added
